### PR TITLE
Fixed a tabulations issue.

### DIFF
--- a/powerline_hgstatus/segments.py
+++ b/powerline_hgstatus/segments.py
@@ -43,9 +43,9 @@ class HgStatusSegment(Segment):
                 missing_files += 1
             elif line[0] == 'M':
                 modified_files += 1
-    	    elif line[0] == 'A':
+            elif line[0] == 'A':
                 added_files += 1
-    	    elif line[0] == 'R':
+            elif line[0] == 'R':
                 removed_files += 1
 
         return modified_files, untracked_files, missing_files, added_files, removed_files


### PR DESCRIPTION
There was a tabulations issue:

```
Python 3.6.0 (default, Jan 16 2017, 12:12:55) 
[GCC 6.3.1 20170109] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import powerline_hgstatus
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/powerline_hgstatus/__init__.py", line 1, in <module>
    from .segments import hgstatus
  File "/usr/lib/python3.6/site-packages/powerline_hgstatus/segments.py", line 46
    elif line[0] == 'A':
                       ^
TabError: inconsistent use of tabs and spaces in indentation
>>> 
```